### PR TITLE
Improve ct_image matching in constructor

### DIFF
--- a/process.py
+++ b/process.py
@@ -61,7 +61,6 @@ class PDACDetectionContainer(SegmentationAlgorithm):
         self.output_dir        = Path("/output/images/")
         self.output_dir_tlm    = Path(os.path.join(self.output_dir,"pancreatic-tumor-likelihood-map")) 
         self.output_dir_seg    = Path(os.path.join(self.output_dir ,"pancreas-anatomy-and-vessel-segmentation"))
-        self.ct_image          = Path(self.ct_ip_dir).glob("*.mha")
         self.heatmap           = self.output_dir_tlm / "heatmap.mha"
         self.segmentation      = self.output_dir_seg / "segmentation.mha"
 
@@ -91,20 +90,20 @@ class PDACDetectionContainer(SegmentationAlgorithm):
         self.output_dir_tlm.mkdir(exist_ok=True, parents=True)
         self.output_dir_seg.mkdir(exist_ok=True, parents=True)
 
-
-
-        print(os.listdir(self.ct_ip_dir))
-
-
-        for fn in os.listdir(self.ct_ip_dir):
-            if ".mha" in fn: self.ct_image = os.path.join(self.ct_ip_dir, fn)
+        # try to find the input CT image
+        try:
+            self.ct_image = next(self.ct_ip_dir.glob("*.mha"))
+            print(f"Found input CT image: {self.ct_image}")
+        except StopIteration:
+            self.ct_image = None
+            print(f"Warning: no input CT image found")
 
     # Note: need to overwrite process because of flexible inputs, which requires custom data loading
     def process(self):
         """
         Load CT scan and Generate Heatmap for Pancreas Cancer  
         """
-        itk_img    = sitk.ReadImage(self.ct_image, sitk.sitkFloat32)
+        itk_img    = sitk.ReadImage(str(self.ct_image), sitk.sitkFloat32)
         image_np   = sitk.GetArrayFromImage(itk_img)
 
         #Get low resolution pancreas segmentation 


### PR DESCRIPTION
Closes #4

This PR implements a new way to match the CT image in the constructor of the `PDACDetectionContainer`.
* This method removes redundant code by only using pathlib `Path.glob`.
* It avoids crashes if the input directory doesn't exist (for use with manual paths)
* It is more efficient because it only picks the first mha file found in the directory and subsequently stops search.
